### PR TITLE
Transition the user from the addEventScreen bug

### DIFF
--- a/app/src/main/java/com/example/giftly/AddEventScreen.java
+++ b/app/src/main/java/com/example/giftly/AddEventScreen.java
@@ -109,7 +109,7 @@ public class AddEventScreen extends AppCompatActivity implements AdapterView.OnI
                             @Override
                             public void onSuccess(String eventID) {
                                 Log.d(TAG, "Successfully Created Event");
-                                Intent intent = new Intent(AddEventScreen.this, DisplayEventScreen.class);
+                                Intent intent = new Intent(AddEventScreen.this, HomeScreen.class);
                                 intent.putExtra("eventID",eventID);
                                 intent.putExtra("new",true);
                                 startActivity(intent);


### PR DESCRIPTION
This change will prevent the user from restarting the app to view the updated events on the home screen after creating one